### PR TITLE
Fix de la fecha de un curso

### DIFF
--- a/src/main/java/com/tecnoinf/gestedu/GestionEducativaOnlineApplication.java
+++ b/src/main/java/com/tecnoinf/gestedu/GestionEducativaOnlineApplication.java
@@ -238,7 +238,7 @@ public class GestionEducativaOnlineApplication {
 				curso2.setEstado(Estado.FINALIZADO);
 				curso2.setAsignatura(asignaturaRepository.findById(1L).get());
 				fechaInicio = LocalDate.of(2023, 3, 15); // Año, Mes (1-12), Día
-				curso1.setFechaInicio(fechaInicio);
+				curso2.setFechaInicio(fechaInicio);
 				fechaFin = LocalDate.of(2023, 07, 15); // Año, Mes (1-12), Día
 				curso2.setFechaFin(fechaFin);
 				curso2.setDocente(docente1);

--- a/src/main/java/com/tecnoinf/gestedu/services/implementations/CursoServiceImpl.java
+++ b/src/main/java/com/tecnoinf/gestedu/services/implementations/CursoServiceImpl.java
@@ -50,11 +50,11 @@ public class CursoServiceImpl implements CursoService {
                 .orElseThrow(() -> new ResourceNotFoundException("Asignatura not found with id " + cursoDTO.getAsignaturaId()));
 
         // Validar que la fecha de inicio sea menor a la fecha de un mes en el futuro
-        LocalDate unMesEnElFuturo = LocalDate.now().plusMonths(1);
+        //LocalDate unMesEnElFuturo = LocalDate.now().plusMonths(1);
 
-        if (cursoDTO.getFechaInicio().isBefore(unMesEnElFuturo)) {
-            throw new IllegalArgumentException("La fecha de inicio no puede ser mayor a la fecha de un mes en el futuro.");
-        }
+        //if (cursoDTO.getFechaInicio().isBefore(unMesEnElFuturo)) {
+            //throw new IllegalArgumentException("La fecha de inicio no puede ser mayor a la fecha de un mes en el futuro.");
+        //}
 
         if (cursoDTO.getFechaInicio().isBefore(cursoDTO.getFechaFin())) {
             Curso curso = new Curso();


### PR DESCRIPTION
Arreglado que no agregaba la fecha de inicio de un curso y quitado el control al agregar una fecha de inicio que sea anterior a la fecha de hoy.